### PR TITLE
add publicationRelationType property in DatasetPublication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /~
 /bin/
 /build/
-/build.gradle
 .classpath
+.factorypath
 .gradle/
 /.gradle/
 gradle.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,41 @@
 Significant changes since 0.1.0
 
-1.0.3 2025-01-28
+# 1.0.4 2025-09-23
 
 New adaptations to ERDG:
 
-- feat: add license property in DatasetVersion
+- feat: add _publicationRelationType_ property in DatasetPublication
 
-1.0.2 2024-08-08
+# 1.0.3 2025-01-28
+
+New adaptations to ERDG:
+
+- feat: add _license_ property in DatasetVersion
+
+# 1.0.2 2024-08-08
 
 New adaptations to ERDG, some fields properties have been updated.
 
-1.0.1 2023-01-04
+# 1.0.1 2023-01-04
 
 Adaptations to ERDG
 
- - feature: All external requests should now throw RestClientException on failure with a reason
- - feature: Added UsersOperations to handle token expiration date.
+- feature: All external requests should now throw RestClientException on failure with a reason
+- feature: Added UsersOperations to handle token expiration date.
 
-1.0.0 2022-11-21
+# 1.0.0 2022-11-21
 
 Increasing major version due to major updates to dependencies. However, there are no
-breaking API changes in this library. 
+breaking API changes in this library.
 
-- dependencies: Major dependency updates to Spring 5.3, Lombok 18.24. 
+- dependencies: Major dependency updates to Spring 5.3, Lombok 18.24.
 - build: fix integration tests
 - build: enable integration test running through Github actions
 - build: test build and test on Java 8, 11, and 17.
 
-0.2.0 2022-11-20
+# 0.2.0 2022-11-20
 
-- build:  update gradlew to use gradle 7.5
-- build:  Basic Github action to run tests on pull request
+- build: update gradlew to use gradle 7.5
+- build: Basic Github action to run tests on pull request
 - dependency: update Lombok from 1.16 to 1.18.4 to enable building on Java 11
 - feature: #12 overloaded method for uploadFile
-

--- a/Readme.md
+++ b/Readme.md
@@ -4,20 +4,20 @@ This project is a Java wrapper around the [Entrepôt Recherche Data Gouv API](ht
 It was initially contributed by [ResearchSpace](www.researchspace.com) in October 2016, and the [main branch](https://github.com/IQSS/dataverse-client-java) is maintained by Richard Adams([otter606](https://github.com/otter606), [richarda23](https://github.com/richarda23)).
 Later contributions around support of [Entrepôt Recherche Data Gouv](https://entrepot.recherche.data.gouv.fr/) (formerly Data INRAE) from L. Tromel, Agroclim, INRAE.
 
-## Building 
+## Building
 
-### Dependencies 
+### Dependencies
 
 This project requires Java 8 minimum to compile and run.
 
 It is built and tested on Java 11 and Java 17.
 
-It also uses Spring-web (to provide low-level HTTP request/response parsing.) 
+It also uses Spring-web (to provide low-level HTTP request/response parsing.)
 
 The Sword client library is included in this project as a jar file, as it is not available
- in a public maven repository.
+in a public maven repository.
 
-### Gradle 
+### Gradle
 
 This project is built using Gradle.
 
@@ -30,13 +30,13 @@ archivaUser=XXXX
 archivaPassword=XXXX
 # archiva URLs
 archivaInternal=http://archiva:9090/archiva/repository/internal/
-ParchivaSnapshots=http://archiva:9090/archiva/repository/snapshots/
+archivaSnapshots=http://archiva:9090/archiva/repository/snapshots/
 ```
 
 You can build straight away without needing to install anything:
 
     ./gradlew clean build -x integrationTest
-   
+
 which will compile, run unit tests (but not integration tests) and build a jar file.
 
 ### Running integration tests
@@ -44,11 +44,11 @@ which will compile, run unit tests (but not integration tests) and build a jar f
 Integration tests require a connection to a Dataverse instance.
 In order to connect to a Dataverse for running tests, the following configuration is set up in `test.properties`.
 
-	dataverseServerURL=https://demo.recherche.data.gouv.fr/
-	dataverseAlias=<any collection with which the token's associated account has necessary rights>
-	
-We recommend you to create a collection with the token's associated account, so the client will have full right on it. 
-    
+    dataverseServerURL=https://demo.recherche.data.gouv.fr/
+    dataverseAlias=<any collection with which the token's associated account has necessary rights>
+
+We recommend you to create a collection with the token's associated account, so the client will have full right on it.
+
 As a minimum, you'll need to specify an API key on the command line to run the tests:
 
     ./gradlew clean integrationTest -DdataverseApiKey=xxx-xxxx-xxxx
@@ -63,7 +63,7 @@ Make sure that almost one dataset is in the Dataverse.
 
 Install the .jar into your .m2 directory:
 
-`gradlew publishToMavenLocal --refresh-dependencies`
+`./gradlew publishToMavenLocal --refresh-dependencies`
 
 then add to your pom.xml:
 
@@ -71,14 +71,14 @@ then add to your pom.xml:
 	<dependency>
 	    <groupId>com.researchspace</groupId>
 	    <artifactId>dataverse-client-java</artifactId>
-	    <version>1.0.3</version>
+	    <version>1.0.4</version>
 	</dependency>
 ```
 
 Or, you can run:
 
     ./gradlew clean install
-    
+
 to install into a local repository and generate a pom.xml file for calculating dependencies.
 
 ### Publishing to a distant archiva repo with current configuration
@@ -118,12 +118,11 @@ Searching uses a builder pattern to build a search query:
 
 ### Synchronisation and thread-safety
 
-There is no explicit synchronisation performed in this library. The Dataverse configuration is stored in the 
-internal state of  implementation classes, so new instances of `DataverseAPIImpl` should be used for each request if running in a multi-threaded environment connecting to different Dataverses.
+There is no explicit synchronisation performed in this library. The Dataverse configuration is stored in the internal state of implementation classes, so new instances of `DataverseAPIImpl` should be used for each request if running in a multi-threaded environment connecting to different Dataverses.
 
 ## Developing
 
-This project makes use of [Project Lombok](https://projectlombok.org) which greatly speeds up the development of POJO classes to wrap JSON data structures. 
+This project makes use of [Project Lombok](https://projectlombok.org) which greatly speeds up the development of POJO classes to wrap JSON data structures.
 
 There are [instructions](https://projectlombok.org/features/index.html) on how to add it to your IDE.
 
@@ -133,21 +132,21 @@ Please make sure tests pass before committing, and to add new tests for new addi
 
 ## Progress
 
-API | Endpoint | URL | Implemented ?| Notes 
-------|----------|-----|--------------|-------
-Native|Dataverses | POST `api/dataverses/$id` | Y| - 
-| -   | -         | GET `api/dataverses/$id` | Y | -
-| -   | -         | GET `api/dataverses/$id/contents` | Y | -
-| -   | -         | DELETE `api/dataverses/$id` | Y | -
-| -   | -         | POST `api/dataverses/$id/datasets` | Y | -
-| -   | -         | POST `api/dataverses/$identifier/actions/:publish` | Y | -
-Native|Datasets | POST `api/dataverses/$id` | Y| -
-| -   | -         | GET `api/datasets/$id` | Y | -
-| -   | -         | DELETE `api/datasets/$id` | Y | -
-| -   | -         | GET `api/datasets/$id/versions` | Y | -
-| -   | -         | GET `PUT api/datasets/$id/versions/:draft?` | Y | -
-| -   | -         | POST `PUT api/datasets/$id/actions/:publish?type=$type` | Y | -
-Native|MetadataBlocks | GET ` api/metadatablocks` | Y| -
-| -   | -         | GET ` api/metadatablocks/$identifier` | Y| -
-Search | - | GET `api/search` | In progress | All query params supported, optional data not returned yet.
-Sword | Upload file | 'Add files to a dataset with a zip file' | Y | -
+| API    | Endpoint       | URL                                                     | Implemented ? | Notes                                                       |
+| ------ | -------------- | ------------------------------------------------------- | ------------- | ----------------------------------------------------------- |
+| Native | Dataverses     | POST `api/dataverses/$id`                               | Y             | -                                                           |
+| -      | -              | GET `api/dataverses/$id`                                | Y             | -                                                           |
+| -      | -              | GET `api/dataverses/$id/contents`                       | Y             | -                                                           |
+| -      | -              | DELETE `api/dataverses/$id`                             | Y             | -                                                           |
+| -      | -              | POST `api/dataverses/$id/datasets`                      | Y             | -                                                           |
+| -      | -              | POST `api/dataverses/$identifier/actions/:publish`      | Y             | -                                                           |
+| Native | Datasets       | POST `api/dataverses/$id`                               | Y             | -                                                           |
+| -      | -              | GET `api/datasets/$id`                                  | Y             | -                                                           |
+| -      | -              | DELETE `api/datasets/$id`                               | Y             | -                                                           |
+| -      | -              | GET `api/datasets/$id/versions`                         | Y             | -                                                           |
+| -      | -              | GET `PUT api/datasets/$id/versions/:draft?`             | Y             | -                                                           |
+| -      | -              | POST `PUT api/datasets/$id/actions/:publish?type=$type` | Y             | -                                                           |
+| Native | MetadataBlocks | GET ` api/metadatablocks`                               | Y             | -                                                           |
+| -      | -              | GET ` api/metadatablocks/$identifier`                   | Y             | -                                                           |
+| Search | -              | GET `api/search`                                        | In progress   | All query params supported, optional data not returned yet. |
+| Sword  | Upload file    | 'Add files to a dataset with a zip file'                | Y             | -                                                           |

--- a/Readme.md
+++ b/Readme.md
@@ -84,7 +84,7 @@ to install into a local repository and generate a pom.xml file for calculating d
 ### Publishing to a distant archiva repo with current configuration
 
 Then run
-`gradlew publish --refresh-dependencies`
+`./gradlew publish --refresh-dependencies`
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 
 group = 'com.researchspace'
 sourceCompatibility = 1.8
-version = '1.0.3'
+version = '1.0.4'
 def springVersion='5.3.24'
 def jacksonVersion='2.11.1'
 def lombokVersion='1.18.24'

--- a/src/integration-test/resources/dataset-builder-test.json
+++ b/src/integration-test/resources/dataset-builder-test.json
@@ -165,6 +165,12 @@
           "typeClass" : "compound",
           "multiple" : true,
           "value" : [ {
+	    "publicationRelationType": {
+		"typeName": "publicationRelationType",
+		"multiple": false,
+		"typeClass": "controlledVocabulary",
+		"value": "IsCitedBy"
+	    },
             "publicationIDType" : {
               "typeName" : "publicationIDType",
               "typeClass" : "controlledVocabulary",

--- a/src/integration-test/resources/dataset-builder-test.json
+++ b/src/integration-test/resources/dataset-builder-test.json
@@ -165,12 +165,12 @@
           "typeClass" : "compound",
           "multiple" : true,
           "value" : [ {
-	    "publicationRelationType": {
-		"typeName": "publicationRelationType",
-		"multiple": false,
-		"typeClass": "controlledVocabulary",
-		"value": "IsCitedBy"
-	    },
+            "publicationRelationType": {
+              "typeName": "publicationRelationType",
+              "multiple": false,
+              "typeClass": "controlledVocabulary",
+              "value": "IsCitedBy"
+            },
             "publicationIDType" : {
               "typeName" : "publicationIDType",
               "typeClass" : "controlledVocabulary",

--- a/src/main/java/com/researchspace/dataverse/entities/facade/DatasetBuilder.java
+++ b/src/main/java/com/researchspace/dataverse/entities/facade/DatasetBuilder.java
@@ -52,6 +52,7 @@ public class DatasetBuilder {
     private static final String PUBLICATION_ID = "publicationIDNumber";
     private static final String PUBLICATION_ID_TYPE = "publicationIDType";
     private static final String PUBLICATION_CITATION= "publicationCitation";
+    private static final String PUBLICATION_RELATION_TYPE = "publicationRelationType";
     private static final String KEYWORD_VOCABULARY_URI = "keywordVocabularyURI";
     private static final String KEYWORD_VOCABULARY = "keywordVocabulary";
     private static final String KEYWORD_VALUE = "keywordValue";
@@ -291,6 +292,8 @@ public class DatasetBuilder {
         final List<Map<String, Object>> list = new ArrayList<>();
         for (final DatasetPublication publication: publications) {
             final Map<String, Object> map = new HashMap<>();
+            final Field publicationRelationType = createControlledVocabField(PUBLICATION_RELATION_TYPE, false, asList(publication.getPublicationRelationType().name()));
+            map.put(PUBLICATION_RELATION_TYPE, publicationRelationType);
             addOptionalPrimitiveField(publication.getPublicationCitation(), map, PUBLICATION_CITATION);
             addOptionalPrimitiveField(publication.getPublicationIdNumber(), map, PUBLICATION_ID);
             if (publication.getPublicationURL() != null) {

--- a/src/main/java/com/researchspace/dataverse/entities/facade/DatasetPublication.java
+++ b/src/main/java/com/researchspace/dataverse/entities/facade/DatasetPublication.java
@@ -29,5 +29,13 @@ public class DatasetPublication {
     private String publicationCitation, publicationIdNumber;
     private PublicationIDType publicationIDType;
     private URL publicationURL;
+    /**
+     * Le 28/07/2025 à 15:40, datainrae a écrit :
+     * > À noter qu'afin d'éviter des erreurs pour les jeux de données
+     * > existants, la valeur "Est cité par" sera appliquée à toutes les
+     * > publications associées existantes.
+     */
+     @Builder.Default
+     private PublicationRelationType publicationRelationType = PublicationRelationType.IsCitedBy;
 
 }

--- a/src/main/java/com/researchspace/dataverse/entities/facade/PublicationRelationType.java
+++ b/src/main/java/com/researchspace/dataverse/entities/facade/PublicationRelationType.java
@@ -1,0 +1,35 @@
+package com.researchspace.dataverse.entities.facade;
+
+/**
+ * Accepted types list for 'publicationRelationType' field.
+ *
+ * Le 28/07/2025 à 15:40, datainrae a écrit :
+ * > Les différentes valeurs possibles sont :
+ * >
+ * > *Est cité par* : Ce jeu de données (ressource décrite) est cité par la
+ * > publication associée. Par exemple une publication dont les résultats sont
+ * > obtenus avec ce jeu de données.
+ * > Ex. de publication : un Article dans une revue, un ouvrage ou chapitre
+ * > d’ouvrage, Rapport
+ * >
+ * > *Cite***: Ce jeu de données (la ressource décrite) cite la
+ * > publication associée. Par exemple si la méthode de collecte est inspirée
+ * > de la publication associée.
+ * > Ex. de publication : un Article dans une revue, un ouvrage ou chapitre
+ * > d’ouvrage, Rapport
+ * >
+ * > *Est le supplément de* : ce jeu de données (la ressource décrite) est un
+ * > supplément de la publication associée. Par exemple si le jeu de données
+ * > consiste en des  supplementary materials, ou des données pouvant servir
+ * > d'exemples complémentaires à la publication.
+ * > Ex. de publication: un Article dans une revue, un ouvrage ou chapitre
+ * > d’ouvrage,
+ * >
+ * > *A pour supplément *: ce jeu de données (la ressource décrite) a comme
+ * > supplément une publication associée. Par exemple un Datapaper apportant
+ * > des compléments sur le jeu de données.
+ * > Ex. de publication : un PGD, un Datapaper, Rapport
+ */
+public enum PublicationRelationType {
+    IsCitedBy, IsSupplementTo;
+}


### PR DESCRIPTION
Le 28/07/2025 à 15:40, datainrae a écrit :
> ce *mercredi 30/07* sera déployé dans Data INRAE une nouvelle 
> fonctionnalité pour mieux renseigner les publications liées et améliorer 
> l'interopérabilité de cette métadonnée. Il s'agit d'un nouveau champ 
> dans le groupe "Publication associée" permettant de préciser la nature 
> du lien entre le jeu de données et la publication
